### PR TITLE
Update onnx/models branch name from "master" to "main"

### DIFF
--- a/data/models/README.md
+++ b/data/models/README.md
@@ -1,3 +1,3 @@
 ```bash
-wget https://github.com/onnx/models/raw/master/vision/classification/squeezenet/model/squeezenet1.1-7.onnx
+wget https://github.com/onnx/models/raw/main/vision/classification/squeezenet/model/squeezenet1.1-7.onnx
 ```


### PR DESCRIPTION
Fix the wget link for the squeezenet model to use the "main" branch name. This is the new branch name that the onnx/models repo is using.